### PR TITLE
Make reading the model in Rest component conform to Index

### DIFF
--- a/core/src/main/scala/org/dbpedia/spotlight/db/SpotlightModel.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/db/SpotlightModel.scala
@@ -93,7 +93,7 @@ object SpotlightModel {
 
     //Load the stemmer from the model file:
     def stemmer(): Stemmer = properties.getProperty("stemmer") match {
-      case s: String if s equals "None" => null
+      case s: String if (s equals "None") || (s equals "NoneStemmer") => new Stemmer()
       case s: String => new SnowballStemmer(s)
     }
 


### PR DESCRIPTION
PR #5 fixed issue when there was no available stemmer for a language:

`if ((args(5) equals "None") || (args (5) equals "NoneStemmer")) new Stemmer() else new SnowballStemmer(args(5))`

However, the saved model is not read properly now.
To address this, SpotlightModel.fromFolder() has to be modified in order to accept None as well as NoneStemmer stored in model.properties and instantiate a default Stemmer which returns a word without processing, since returning a null may lead to NullPointerExceptions.

