### PR TITLE
CreateSpotlightModel without using stopwords file

### DIFF
--- a/index/src/main/scala/org/dbpedia/spotlight/db/CreateSpotlightModel.scala
+++ b/index/src/main/scala/org/dbpedia/spotlight/db/CreateSpotlightModel.scala
@@ -46,7 +46,7 @@ object CreateSpotlightModel {
         new File(args(1)), // raw data folder
         new File(args(2)), // output folder
         if (args(3) equals "None") None else Some(new File(args(3))), // openNLP
-        new File(args(4)), // stopwords
+        if (args(4) equals "None") None else new File(args(4)), // stopwords
         if ((args(5) equals "None") || (args (5) equals "NoneStemmer")) new Stemmer() else new SnowballStemmer(args(5)) // stemmer
         )
     } catch {


### PR DESCRIPTION
This commit doesn't break the interface.
We are just now allowed to pass None if we don't want to filter out any words.