### PR TITLE
Less verbose logs by default

### DIFF
--- a/core/src/main/scala/org/dbpedia/spotlight/filter/annotations/ConfidenceFilter.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/filter/annotations/ConfidenceFilter.scala
@@ -31,7 +31,7 @@ class PercentageOfSecondFilter(val confidence : Double) extends AnnotationFilter
 
     override def touchOcc(occ : DBpediaResourceOccurrence) : Option[DBpediaResourceOccurrence] = {
         if(occ.percentageOfSecondRank > (1-squaredConfidence)) {
-            SpotlightLog.info(this.getClass, "(c=%s) filtered out by threshold of second ranked percentage (%.3f>%.3f): %s", confidence,occ.percentageOfSecondRank, 1-squaredConfidence, occ)
+            SpotlightLog.debug(this.getClass, "(c=%s) filtered out by threshold of second ranked percentage (%.3f>%.3f): %s", confidence,occ.percentageOfSecondRank, 1-squaredConfidence, occ)
             None
         }
         else {
@@ -51,7 +51,7 @@ class ConfidenceFilter(val simThresholds : List[Double], val confidence : Double
     val simThreshold = if (simThresholds.length==0) confidence else simThresholds(math.max(((simThresholds.length-1)*confidence).round.toInt, 0))
     override def touchOcc(occ : DBpediaResourceOccurrence) : Option[DBpediaResourceOccurrence] = {
         if(occ.similarityScore < simThreshold) {
-            SpotlightLog.info(this.getClass, "(c=%s) filtered out by similarity score threshold (%.3f<%.3f): %s", confidence, occ.similarityScore, simThreshold, occ)
+            SpotlightLog.debug(this.getClass, "(c=%s) filtered out by similarity score threshold (%.3f<%.3f): %s", confidence, occ.similarityScore, simThreshold, occ)
             None
         }
         else {

--- a/core/src/main/scala/org/dbpedia/spotlight/filter/annotations/SupportFilter.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/filter/annotations/SupportFilter.scala
@@ -32,7 +32,7 @@ class SupportFilter(val targetSupport : Int) extends AnnotationFilter with Filte
             Some(occ)
         }
         else{
-            SpotlightLog.info(this.getClass, "filtered out by support (%d<%d): %s", occ.resource.support, targetSupport, occ)
+            SpotlightLog.debug(this.getClass, "filtered out by support (%d<%d): %s", occ.resource.support, targetSupport, occ)
             None
         }
     }

--- a/core/src/main/scala/org/dbpedia/spotlight/filter/annotations/TypeFilter.scala
+++ b/core/src/main/scala/org/dbpedia/spotlight/filter/annotations/TypeFilter.scala
@@ -31,7 +31,7 @@ class TypeFilter(var ontologyTypes : List[OntologyType], val blacklistOrWhitelis
     else
         ontologyTypes = ontologyTypes.filter(_.typeID.trim.nonEmpty)
 
-    if(ontologyTypes.isEmpty) SpotlightLog.info(this.getClass, "types are empty: showing all types")  // see comment below
+    if(ontologyTypes.isEmpty) SpotlightLog.debug(this.getClass, "types are empty: showing all types")  // see comment below
 
 
     private val acceptable = blacklistOrWhitelist match {

--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
-                <version>1.6.1</version>
+                <version>1.7.25</version>
                 <!--
                     License: Apache Software License, Version 2.0
                 -->

--- a/rest/src/main/java/org/dbpedia/spotlight/web/rest/SpotlightInterface.java
+++ b/rest/src/main/java/org/dbpedia/spotlight/web/rest/SpotlightInterface.java
@@ -97,21 +97,21 @@ public class SpotlightInterface {
                          String clientIp,
                          String spotterName,
                          String disambiguatorName) {
-        LOG.info("******************************** Parameters ********************************");
-        LOG.info("API: " + getApiName());
-        LOG.info("client ip: " + clientIp);
-        LOG.info("text: " + textString);
+        LOG.debug("******************************** Parameters ********************************");
+        LOG.debug("API: " + getApiName());
+        LOG.debug("client ip: " + clientIp);
+        LOG.debug("text: " + textString);
         if (textString != null) {
-            LOG.info("text length in chars: " + textString.length());
+            LOG.debug("text length in chars: " + textString.length());
         }
-        LOG.info("confidence: " + String.valueOf(confidence));
-        LOG.info("support: " + String.valueOf(support));
-        LOG.info("types: " + ontologyTypesString);
-        LOG.info("sparqlQuery: " + sparqlQuery);
-        LOG.info("policy: " + policyIsBlacklist(policy));
-        LOG.info("coreferenceResolution: " + String.valueOf(coreferenceResolution));
-        LOG.info("spotter: " + spotterName);
-        LOG.info("disambiguator: " + disambiguatorName);
+        LOG.debug("confidence: " + String.valueOf(confidence));
+        LOG.debug("support: " + String.valueOf(support));
+        LOG.debug("types: " + ontologyTypesString);
+        LOG.debug("sparqlQuery: " + sparqlQuery);
+        LOG.debug("policy: " + policyIsBlacklist(policy));
+        LOG.debug("coreferenceResolution: " + String.valueOf(coreferenceResolution));
+        LOG.debug("spotter: " + spotterName);
+        LOG.debug("disambiguator: " + disambiguatorName);
 
     }
 
@@ -199,7 +199,7 @@ public class SpotlightInterface {
             List<DBpediaResourceOccurrence> occs = getOccurrences(textToProcess, confidence, support, dbpediaTypesString, sparqlQuery, policy, coreferenceResolution, clientIp, spotter, disambiguator);
             result = outputManager.makeHTML(textToProcess, occs);
         } catch (InputException e) { //TODO throw exception up to Annotate for WebApplicationException to handle.
-            LOG.info("ERROR: " + e.getMessage());
+            LOG.error("ERROR: " + e.getMessage());
             result = "<html><body><b>ERROR:</b> <i>" + e.getMessage() + "</i></body></html>";
         }
         LOG.info("HTML format");
@@ -226,7 +226,7 @@ public class SpotlightInterface {
             List<DBpediaResourceOccurrence> occs = getOccurrences(textToProcess, confidence, support, dbpediaTypesString, sparqlQuery, policy, coreferenceResolution, clientIp, spotter, disambiguator);
             result = outputManager.makeRDFa(textToProcess, occs);
         } catch (InputException e) { //TODO throw exception up to Annotate for WebApplicationException to handle.
-            LOG.info("ERROR: " + e.getMessage());
+            LOG.error("ERROR: " + e.getMessage());
             result = "<html><body><b>ERROR:</b> <i>" + e.getMessage() + "</i></body></html>";
         }
         LOG.info("RDFa format");
@@ -251,7 +251,7 @@ public class SpotlightInterface {
         List<DBpediaResourceOccurrence> occs = getOccurrences(textToProcess, confidence, support, dbpediaTypesString, sparqlQuery, policy, coreferenceResolution, clientIp, spotter, disambiguator);
         result = outputManager.makeXML(textToProcess, occs, confidence, support, dbpediaTypesString, sparqlQuery, policy, coreferenceResolution);
 
-        LOG.info("XML format");
+        LOG.debug("XML format");
         LOG.debug("****************************************************************");
 
         return result;
@@ -310,7 +310,7 @@ public class SpotlightInterface {
 
         List<DBpediaResourceOccurrence> occs = getOccurrences(textToProcess, confidence, support, dbpediaTypesString, sparqlQuery, policy, coreferenceResolution, clientIp, spotter, disambiguator);
         result = outputManager.makeXML(textToProcess, occs, confidence, support, dbpediaTypesString, sparqlQuery, policy, coreferenceResolution);
-        LOG.info("XML format");
+        LOG.debug("XML format");
         LOG.debug("****************************************************************");
         return result;
     }


### PR DESCRIPTION
Less verbose logs by changing lot's of INFO levels to DEBUG.
By default, spotlight logs run in INFO mode (with slf4j).
By updating slf4j to 1.7.x, we can now run spotlight at the default log level we want with the `-Dorg.slf4j.simpleLogger.defaultLogLevel=$loglevel` switch.

This try to fix https://github.com/dbpedia-spotlight/dbpedia-spotlight/issues/453 and other older bugs.