### PR TITLE
Even less logs by default

### DIFF
--- a/rest/src/main/java/org/dbpedia/spotlight/web/rest/ServerUtils.java
+++ b/rest/src/main/java/org/dbpedia/spotlight/web/rest/ServerUtils.java
@@ -55,7 +55,7 @@ public class ServerUtils {
         if (text != null && !text.equals("")) {
             textToProcess = text;
         } else if (inUrl != null && !inUrl.equals("")) {
-            LOG.info("Parsing URL to get main content");
+            LOG.debug("Parsing URL to get main content");
             try {
                 URL url = new URL(inUrl);
                 InputSource is = new InputSource();

--- a/rest/src/main/java/org/dbpedia/spotlight/web/rest/SpotlightInterface.java
+++ b/rest/src/main/java/org/dbpedia/spotlight/web/rest/SpotlightInterface.java
@@ -161,7 +161,7 @@ public class SpotlightInterface {
         if (Server.getTokenizer() == null && disambiguatorName.equals(SpotlightConfiguration.DisambiguationPolicy.Default.name())
                 && textString.length() > maxLengthForOccurrenceCentric) {
             disambiguatorName = SpotlightConfiguration.DisambiguationPolicy.Document.name();
-            LOG.info(String.format("Text length > %d. Using %s to disambiguate.", maxLengthForOccurrenceCentric, disambiguatorName));
+            LOG.debug(String.format("Text length > %d. Using %s to disambiguate.", maxLengthForOccurrenceCentric, disambiguatorName));
         }
         ParagraphDisambiguatorJ disambiguator = Server.getDisambiguator(disambiguatorName);
         List<DBpediaResourceOccurrence> occList = disambiguate(spots, disambiguator);
@@ -202,7 +202,7 @@ public class SpotlightInterface {
             LOG.error("ERROR: " + e.getMessage());
             result = "<html><body><b>ERROR:</b> <i>" + e.getMessage() + "</i></body></html>";
         }
-        LOG.info("HTML format");
+        LOG.debug("HTML format");
         LOG.debug("****************************************************************");
         return result;
     }
@@ -229,7 +229,7 @@ public class SpotlightInterface {
             LOG.error("ERROR: " + e.getMessage());
             result = "<html><body><b>ERROR:</b> <i>" + e.getMessage() + "</i></body></html>";
         }
-        LOG.info("RDFa format");
+        LOG.debug("RDFa format");
         LOG.debug("****************************************************************");
         return result;
     }
@@ -286,7 +286,7 @@ public class SpotlightInterface {
         List<DBpediaResourceOccurrence> occs = getOccurrences(textToProcess, confidence, support, dbpediaTypesString, sparqlQuery, policy, coreferenceResolution, clientIp, spotter, disambiguator);
         result = outputManager.makeNIF(textToProcess, occs, format, prefix);
 
-        LOG.info("NIF format: " + format);
+        LOG.debug("NIF format: " + format);
         LOG.debug("****************************************************************");
 
         return result;

--- a/rest/src/main/java/org/dbpedia/spotlight/web/rest/resources/Candidates.java
+++ b/rest/src/main/java/org/dbpedia/spotlight/web/rest/resources/Candidates.java
@@ -87,10 +87,10 @@ public class Candidates {
         List<SurfaceFormOccurrence> entityMentions = spotter.extract(textObject);
         if (entityMentions.size()==0) return annotation; //nothing to disambiguate
         Paragraph paragraph = Factory.paragraph().fromJ(entityMentions);
-        LOG.info(String.format("Spotted %d entity mentions.",entityMentions.size()));
+        LOG.debug(String.format("Spotted %d entity mentions.",entityMentions.size()));
 
         Map<SurfaceFormOccurrence,List<DBpediaResourceOccurrence>> entityCandidates = disambiguator.bestK(paragraph,k);
-        LOG.info(String.format("Disambiguated %d candidates with %s.",entityCandidates.size(),disambiguator.name()));
+        LOG.debug(String.format("Disambiguated %d candidates with %s.",entityCandidates.size(),disambiguator.name()));
 
         Enumeration.Value listColor = blacklist ? FilterPolicy$.MODULE$.Blacklist() : FilterPolicy$.MODULE$.Whitelist();
 
@@ -183,7 +183,7 @@ public class Candidates {
         try {
             String textToProcess = ServerUtils.getTextToProcess(text, inUrl);
             Annotation a = getAnnotation(textToProcess, confidence, support, dbpediaTypes, sparqlQuery, policy, coreferenceResolution, spotter, disambiguatorName, clientIp);
-            LOG.info("XML format");
+            LOG.debug("XML format");
             String content = a.toXML();
             return ServerUtils.ok(content);
         } catch (Exception e) {
@@ -209,7 +209,7 @@ public class Candidates {
         try {
             String textToProcess = ServerUtils.getTextToProcess(text, inUrl);
             Annotation a = getAnnotation(textToProcess, confidence, support, dbpediaTypes, sparqlQuery, policy, coreferenceResolution, spotter, disambiguatorName, clientIp);
-            LOG.info("JSON format");
+            LOG.debug("JSON format");
             String content = a.toJSON();
             return ServerUtils.ok(content);
         } catch (Exception e) {
@@ -299,7 +299,7 @@ public class Candidates {
                                     String disambiguatorName,
                                     String clientIp) throws SearchException, InputException, ItemNotFoundException, SpottingException, MalformedURLException, BoilerpipeProcessingException {
 
-        LOG.info("******************************** Parameters ********************************");
+        LOG.debug("******************************** Parameters ********************************");
         //announceAPI();
 
         boolean blacklist = false;
@@ -310,17 +310,17 @@ public class Candidates {
         else {
             policy = "whitelist";
         }
-        LOG.info("client ip: " + clientIp);
-        LOG.info("text to be processed: " + text);
-        LOG.info("text length in chars: "+ text.length());
-        LOG.info("confidence: "+String.valueOf(confidence));
-        LOG.info("support: "+String.valueOf(support));
-        LOG.info("types: "+ontologyTypesString);
-        LOG.info("sparqlQuery: "+ sparqlQuery);
-        LOG.info("policy: "+policy);
-        LOG.info("coreferenceResolution: "+String.valueOf(coreferenceResolution));
-        LOG.info("spotter: "+ spotterName);
-        LOG.info("disambiguator: " + disambiguatorName);
+        LOG.debug("client ip: " + clientIp);
+        LOG.debug("text to be processed: " + text);
+        LOG.debug("text length in chars: "+ text.length());
+        LOG.debug("confidence: "+String.valueOf(confidence));
+        LOG.debug("support: "+String.valueOf(support));
+        LOG.debug("types: "+ontologyTypesString);
+        LOG.debug("sparqlQuery: "+ sparqlQuery);
+        LOG.debug("policy: "+policy);
+        LOG.debug("coreferenceResolution: "+String.valueOf(coreferenceResolution));
+        LOG.debug("spotter: "+ spotterName);
+        LOG.debug("disambiguator: " + disambiguatorName);
 
         /* Validating parameters */
 
@@ -332,7 +332,7 @@ public class Candidates {
         if (Server.getTokenizer() == null && disambiguatorName==SpotlightConfiguration.DisambiguationPolicy.Default.name()
                 && text.length() > 1200) {
             disambiguatorName = SpotlightConfiguration.DisambiguationPolicy.Document.name();
-            LOG.info(String.format("Text length: %d. Using %s to disambiguate.",text.length(),disambiguatorName));
+            LOG.debug(String.format("Text length: %d. Using %s to disambiguate.",text.length(),disambiguatorName));
         }
 
         Spotter spotter = Server.getSpotter(spotterName);


### PR DESCRIPTION
As requested, here's my extension of #9 

It eliminates INFO-level logs that may occur during a request. The theory being that anything that makes noise during a request will fill the disk, as was my experience. (had to create an hourly cron job that would wipe syslog!)

Nothing terribly special in this PR, just a pile of `info` changes to `debug`.

cc @Skunnyk 