### PR TITLE
Added configurable thread counts and post sizing

### DIFF
--- a/rest/src/main/java/org/dbpedia/spotlight/web/rest/Server.java
+++ b/rest/src/main/java/org/dbpedia/spotlight/web/rest/Server.java
@@ -94,12 +94,22 @@ public class Server {
         initParams.put("com.sun.jersey.config.property.packages", "org.dbpedia.spotlight.web.rest.resources");
         initParams.put("com.sun.jersey.config.property.WadlGeneratorConfig", "org.dbpedia.spotlight.web.rest.wadl.ExternalUriWadlGeneratorConfig");
 
+        // Configurable thread sizing
+        int maxThreads = Integer.parseInt(System.getProperty("threads.max", "5"));
+        int coreThreads = Integer.parseInt(System.getProperty("threads.core", "5"));
+        int maxPostSize = Integer.parseInt(System.getProperty("post.size.max", "2097152")); // 2MB
 
         SelectorThread threadSelector = GrizzlyWebContainerFactory.create(serverURI, initParams);
+        threadSelector.setMaxThreads(maxThreads);
+        threadSelector.setCoreThreads(coreThreads);
+        threadSelector.setMaxPostSize(maxPostSize);
         threadSelector.start();
 
         System.err.println("Server started in " + System.getProperty("user.dir") + " listening on " + serverURI);
 
+        LOG.info(String.format(" Core threads: %d", threadSelector.getCoreThreads()));
+        LOG.info(String.format("  Max threads: %d", threadSelector.getMaxThreads()));
+        LOG.info(String.format("Max POST size: %d", threadSelector.getMaxPostSize()));
 
         while(running) {
             Thread.sleep(100);


### PR DESCRIPTION
As requested per @Skunnyk (dbpedia-spotlight#3) , I've moved this change set here for PR.

It adds three runtime parameters:

* `threads.max` to regulate how many threads the server can utilize (default: `5`)
* `threads.core` to define how many threads the server starts with (default: `5`)
* `post.size.max` to define the maximum POST-request payload size (default: `2097152` aka 2MB)

They can be tacked on at execution like so:
`java -Xmx14G -Dthreads.max=10 -Dthreads.core=10 -Dpost.size.max=10485760 -jar ...`