### PR TITLE
Update The Central Repository url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -928,7 +928,7 @@
             <id>central</id>
             <name>Maven Repository Switchboard</name>
             <layout>default</layout>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
It was replaced http://repo1.maven.org/maven2/ with https://repo1.maven.org/maven2/ since the former send "501 HTTPS Required. " error.
